### PR TITLE
Standard ebooks and unglue.it

### DIFF
--- a/bin/standard_ebooks_monitor
+++ b/bin/standard_ebooks_monitor
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Update the content server with new books from Standard eBooks."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import OPDSImportScript
+from core.opds_import import OPDSImporter
+from core.model import DataSource
+OPDSImportScript("https://standardebooks.org/opds/all", DataSource.STANDARD_EBOOKS, OPDSImporter).run()

--- a/bin/standard_ebooks_monitor
+++ b/bin/standard_ebooks_monitor
@@ -6,6 +6,6 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import OPDSImportScript
-from core.opds_import import OPDSImporter
+from opds_import import ContentOPDSImporter
 from core.model import DataSource
-OPDSImportScript("https://standardebooks.org/opds/all", DataSource.STANDARD_EBOOKS, OPDSImporter).run()
+OPDSImportScript("https://standardebooks.org/opds/all", DataSource.STANDARD_EBOOKS, ContentOPDSImporter).run()

--- a/bin/unglue_it_monitor
+++ b/bin/unglue_it_monitor
@@ -8,4 +8,4 @@ sys.path.append(os.path.abspath(package_dir))
 from core.scripts import OPDSImportScript
 from opds_import import ContentOPDSImporter
 from core.model import DataSource
-OPDSImportScript("https://unglue.it/api/opds/epub/?order_by=newest&page=102", DataSource.UNGLUE_IT, ContentOPDSImporter).run()
+OPDSImportScript("https://unglue.it/api/opds/epub/", DataSource.UNGLUE_IT, ContentOPDSImporter).run()

--- a/bin/unglue_it_monitor
+++ b/bin/unglue_it_monitor
@@ -6,6 +6,6 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import OPDSImportScript
-from opds_import import ContentOPDSImporter
+from opds_import import UnglueItOPDSImporter
 from core.model import DataSource
-OPDSImportScript("https://unglue.it/api/opds/epub/", DataSource.UNGLUE_IT, ContentOPDSImporter).run()
+OPDSImportScript("https://unglue.it/api/opds/epub/", DataSource.UNGLUE_IT, UnglueItOPDSImporter).run()

--- a/bin/unglue_it_monitor
+++ b/bin/unglue_it_monitor
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Update the content server with new books from unglue.it."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import OPDSImportScript
+from core.opds_import import OPDSImporter
+from core.model import DataSource
+OPDSImportScript("https://unglue.it/api/opds/epub/", DataSource.UNGLUE_IT, OPDSImporter).run()

--- a/bin/unglue_it_monitor
+++ b/bin/unglue_it_monitor
@@ -6,6 +6,6 @@ bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
 from core.scripts import OPDSImportScript
-from core.opds_import import OPDSImporter
+from opds_import import ContentOPDSImporter
 from core.model import DataSource
-OPDSImportScript("https://unglue.it/api/opds/epub/", DataSource.UNGLUE_IT, OPDSImporter).run()
+OPDSImportScript("https://unglue.it/api/opds/epub/?order_by=newest&page=102", DataSource.UNGLUE_IT, ContentOPDSImporter).run()

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -432,7 +432,7 @@ class GutenbergRDFExtractor(object):
 
         metadata = Metadata(
             data_source=DataSource.GUTENBERG,
-            book_data_source=DataSource.GUTENBERG,
+            license_data_source=DataSource.GUTENBERG,
             title=title,
             subtitle=subtitle,
             language=language,
@@ -446,6 +446,7 @@ class GutenbergRDFExtractor(object):
             links=links,
         )
         edition, new = metadata.edition(_db)
+        metadata.apply(edition)
         return edition, rights_uri, new
 
 

--- a/marc.py
+++ b/marc.py
@@ -58,7 +58,7 @@ class MARCExtractor(object):
 
             metadata_records.append(Metadata(
                 data_source=data_source_name,
-                book_data_source=data_source_name,
+                license_data_source=data_source_name,
                 title=title,
                 language='eng',
                 medium=Edition.BOOK_MEDIUM,

--- a/opds_import.py
+++ b/opds_import.py
@@ -25,7 +25,7 @@ class ContentOPDSImporter(OPDSImporter):
                 original_url = link.resource.url
 
                 mirror_url = None
-                if media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
+                if media_type in Representation.BOOK_MEDIA_TYPES:
                     extension = Representation.FILE_EXTENSIONS.get(media_type)
                     mirror_url = uploader.book_url(edition.primary_identifier, extension=extension, title=edition.title)
                 elif link.rel == Hyperlink.THUMBNAIL_IMAGE or link.rel == Hyperlink.IMAGE:
@@ -63,7 +63,7 @@ class UnglueItOPDSImporter(ContentOPDSImporter):
             other_links = []
             
             for link in metadata_obj.links:
-                if link.media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
+                if link.media_type in Representation.BOOK_MEDIA_TYPES:
                     book_links.append(deepcopy(link))
                 else:
                     other_links.append(deepcopy(link))

--- a/opds_import.py
+++ b/opds_import.py
@@ -1,0 +1,46 @@
+from core.opds_import import OPDSImporter
+from core.s3 import S3Uploader
+from core.model import (
+    Representation,
+    Hyperlink,
+    DataSource,
+)
+from urllib import urlopen
+from nose.tools import set_trace
+
+class ContentOPDSImporter(OPDSImporter):
+
+    def import_from_feed(self, feed):
+        imported, messages, next_links = super(ContentOPDSImporter, self).import_from_feed(feed)
+
+        # Mirror books and images to S3 for the imported editions
+        uploader = S3Uploader()
+        for edition in imported:
+            links = edition.primary_identifier.links
+            for link in links:
+                representation = link.resource.representation
+                media_type = representation.media_type
+                original_url = link.resource.url
+
+                mirror_url = None
+                if media_type == Representation.EPUB_MEDIA_TYPE:
+                    mirror_url = uploader.book_url(edition.primary_identifier, "epub")
+                elif link.rel == Hyperlink.THUMBNAIL_IMAGE or link.rel == Hyperlink.IMAGE:
+                    data_source = DataSource.lookup(self._db, self.data_source_name)
+                    mirror_url = uploader.cover_image_url(data_source, edition.primary_identifier, original_url.split("/")[-1])
+               
+                if mirror_url:
+                    try:
+                        representation.mirror_url = mirror_url
+                        handle = urlopen(original_url)
+                        content = handle.read()
+                        handle.close()
+                        representation.content = content
+                        uploader.mirror_one(representation)
+                        representation.content = None
+                        edition.work.set_presentation_ready()
+                    except IOError as e:
+                        print "Unable to mirror %s" % original_url
+                        representation.mirror_url = None
+
+        return imported, messages, next_links

--- a/opds_import.py
+++ b/opds_import.py
@@ -26,7 +26,8 @@ class ContentOPDSImporter(OPDSImporter):
 
                 mirror_url = None
                 if media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
-                    mirror_url = uploader.book_url(edition.primary_identifier, extension="epub", title=edition.title)
+                    extension = Representation.FILE_EXTENSIONS.get(media_type)
+                    mirror_url = uploader.book_url(edition.primary_identifier, extension=extension, title=edition.title)
                 elif link.rel == Hyperlink.THUMBNAIL_IMAGE or link.rel == Hyperlink.IMAGE:
                     data_source = DataSource.lookup(self._db, self.data_source_name)
                     mirror_url = uploader.cover_image_url(data_source, edition.primary_identifier, original_url.split("/")[-1])

--- a/opds_import.py
+++ b/opds_import.py
@@ -6,9 +6,11 @@ from core.model import (
     DataSource,
 )
 from urllib import urlopen
+from copy import deepcopy
 from nose.tools import set_trace
 
 class ContentOPDSImporter(OPDSImporter):
+    """OPDS Importer that mirrors content to S3."""
 
     def import_from_feed(self, feed):
         imported, messages, next_links = super(ContentOPDSImporter, self).import_from_feed(feed)
@@ -44,3 +46,35 @@ class ContentOPDSImporter(OPDSImporter):
                         representation.mirror_url = None
 
         return imported, messages, next_links
+
+
+class UnglueItOPDSImporter(ContentOPDSImporter):
+    """Importer for unglue.it OPDS feed, which has acquisition links from multiple sources for some entries."""
+
+    def extract_metadata(self, feed):
+        metadata = []
+
+        entry_metadata_objs, status_messages, next_links = super(UnglueItOPDSImporter, self).extract_metadata(feed)
+
+        for metadata_obj in entry_metadata_objs:
+            book_links = []
+            other_links = []
+            
+            for link in metadata_obj.links:
+                if link.media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
+                    book_links.append(deepcopy(link))
+                else:
+                    other_links.append(deepcopy(link))
+
+            if len(book_links) > 1:
+                # Create a different metadata object for each book link
+                for link in book_links:
+                    metadata_copy = deepcopy(metadata_obj)
+                    metadata_copy.links = [link] + other_links
+                    metadata_copy.rights_uri = link.rights_uri
+                    metadata.append(metadata_copy)
+            else:
+                metadata.append(metadata_obj)
+
+        return metadata, status_messages, next_links
+        

--- a/opds_import.py
+++ b/opds_import.py
@@ -26,7 +26,7 @@ class ContentOPDSImporter(OPDSImporter):
 
                 mirror_url = None
                 if media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
-                    mirror_url = uploader.book_url(edition.primary_identifier, "epub")
+                    mirror_url = uploader.book_url(edition.primary_identifier, extension="epub", title=edition.title)
                 elif link.rel == Hyperlink.THUMBNAIL_IMAGE or link.rel == Hyperlink.IMAGE:
                     data_source = DataSource.lookup(self._db, self.data_source_name)
                     mirror_url = uploader.cover_image_url(data_source, edition.primary_identifier, original_url.split("/")[-1])

--- a/opds_import.py
+++ b/opds_import.py
@@ -23,7 +23,7 @@ class ContentOPDSImporter(OPDSImporter):
                 original_url = link.resource.url
 
                 mirror_url = None
-                if media_type == Representation.EPUB_MEDIA_TYPE:
+                if media_type in Representation.SUPPORTED_BOOK_MEDIA_TYPES:
                     mirror_url = uploader.book_url(edition.primary_identifier, "epub")
                 elif link.rel == Hyperlink.THUMBNAIL_IMAGE or link.rel == Hyperlink.IMAGE:
                     data_source = DataSource.lookup(self._db, self.data_source_name)

--- a/opds_import.py
+++ b/opds_import.py
@@ -44,6 +44,7 @@ class ContentOPDSImporter(OPDSImporter):
                         edition.work.set_presentation_ready()
                     except IOError as e:
                         print "Unable to mirror %s" % original_url
+                        representation.mirror_exception = str(e)
                         representation.mirror_url = None
 
         return imported, messages, next_links

--- a/scripts.py
+++ b/scripts.py
@@ -178,7 +178,6 @@ class DirectoryImportScript(Script):
                 ))
 
                 metadata.formats = formats
-                metadata.rights_uri = RightsStatus.PUBLIC_DOMAIN_USA
 
                 license_pool, new_license_pool = metadata.license_pool(self._db)
                 edition, new = metadata.edition(self._db)

--- a/scripts.py
+++ b/scripts.py
@@ -10,6 +10,7 @@ from core.model import (
     Representation,
     DeliveryMechanism,
     Hyperlink,
+    RightsStatus,
     get_one,
 )
 from core.classifier import Classifier
@@ -177,9 +178,11 @@ class DirectoryImportScript(Script):
                 ))
 
                 metadata.formats = formats
+                metadata.rights_uri = RightsStatus.PUBLIC_DOMAIN_USA
 
                 license_pool, new_license_pool = metadata.license_pool(self._db)
                 edition, new = metadata.edition(self._db)
+                metadata.apply(edition)
                 if new_license_pool:
                     license_pool.edition = edition
 
@@ -188,11 +191,11 @@ class DirectoryImportScript(Script):
 
                 if new:
                     print "created new edition %s" % edition.title
-                
                 for link in edition.primary_identifier.links:
-                    representation = link.resource.representation
-                    representation.mirror_url = link.resource.url
-                    representation.local_content_path = paths[link.resource.url]
-                    uploader.mirror_one(representation)   
+                    if "description" not in link.rel:
+                        representation = link.resource.representation
+                        representation.mirror_url = link.resource.url
+                        representation.local_content_path = paths[link.resource.url]
+                        uploader.mirror_one(representation)   
 
                 self._db.commit()


### PR DESCRIPTION
Monitors for standard ebooks and unglue.it which also mirror content and covers to S3. 

This depends on the branch opds-import-metadata-layer in core and these prs:
https://github.com/NYPL/Simplified-server-core/pull/11
https://github.com/NYPL/Simplified-server-core/pull/12
https://github.com/NYPL/Simplified-server-core/pull/13
https://github.com/NYPL/Simplified-server-core/pull/16

This connects to #12. 