### PR TITLE
Setup travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+addons:
+  postgresql: "9.3"
+
+services:
+  - postgresql
+
+before_script:
+  - psql -c 'create role simplified_test;' -U postgres
+  - psql -c 'create database simplified_content_test;' -U postgres
+  - psql -c 'grant all privileges on database simplified_content_test to simplified_test;' -U postgres
+
+language: python
+
+python:
+  - "2.7"
+
+install:
+  - git submodule init
+  - git submodule update
+  - pip install -r requirements.txt
+  - cp config.json.sample config.json
+  - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
+
+script: ./test

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,18 @@
+{
+    "gutenberg_illustrated_binary_path" : "",
+    "data_directory" : "",
+    "policies" : {
+        
+    },
+    "integrations" : {
+    	"Postgres" : {
+    	    "test_url" : "postgres://simplified_test:test@localhost:5432/simplified_content_test"
+    	},
+
+    	"Content Server": {
+    	},
+        
+    	"S3" : {
+    	}
+    }
+}


### PR DESCRIPTION
A first pass at setting up travis CI, though it may need some tweaking once it's online.

This adds a sample config file internal to the repo. Travis needs this information, but with some well placed comments, it can become helpful documentation to folks who are setting up the repo for themselves.

That's for the future, though. For now, let's get some continuous integration up and running.

Closes #14.